### PR TITLE
Fixed breadcrumb - removed dev/training

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,13 +11,11 @@ crumbs:
   - link: http://www.ucl.ac.uk/ISD
     text: ISD
   - link: http://www.ucl.ac.uk/isd/services
-    text: OUR SERVICES
-  - link: http://www.ucl.ac.uk/isd/services/research_it
-    text: RESEARCH IT
-  - link: http://www.ucl.ac.uk/isd/services/research_it/training
-    text: TRAINING
-  - link: http://development.rc.ucl.ac.uk/training
-    text: MATERIALS
+    text: Our Services
+  - link: http://www.ucl.ac.uk/isd/services/research-it
+    text: Research IT
+  - link: http://www.ucl.ac.uk/isd/services/research-it/training
+    text: Training
 
 baseurl: /training/introductory
 


### PR DESCRIPTION
Removed development.rc.ucl.ac.uk/training from breadcrumb
Changed text to title case as per main ISD site