### PR TITLE
Changing from yaml.load to yaml.safe_load

### DIFF
--- a/notebooks/064JsonYamlXML.ipynb
+++ b/notebooks/064JsonYamlXML.ipynb
@@ -299,28 +299,9 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_105427/3199521527.py:1: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n",
-      "  yaml.load(open('myfile.yaml'))\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'somekey': ['a list', 'with values', [1, 2, 4]]}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "yaml.load(open('myfile.yaml'))"
+    "yaml.safe_load(open('myfile.yaml'))"
    ]
   },
   {

--- a/notebooks/065MazeSaved.ipynb
+++ b/notebooks/065MazeSaved.ipynb
@@ -229,7 +229,7 @@
    "outputs": [],
    "source": [
     "with open('maze.yaml') as yaml_maze_in:\n",
-    "    maze_again = yaml.load(yaml_maze_in)"
+    "    maze_again = yaml.safe_load(yaml_maze_in)"
    ]
   },
   {


### PR DESCRIPTION
Changes usages of `yaml.load` function to instead use `yaml.safe_load` which is an alias for `yaml.load` with the `Loader` argument set to `yaml.SafeLoader`. This  avoids a `YAMLLoadWarning` being displayed indicating calling `yaml.load` without a `Loader` argument has been deprecated with a link to the explanation at https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation