### PR TITLE
Fix module path

### DIFF
--- a/notebooks/050import.ipynb
+++ b/notebooks/050import.ipynb
@@ -215,28 +215,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can always find out where on your storage medium a library has been imported from:"
+    "You can find out where on your storage medium a library has been imported from:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'matplotlib'",
+     "ename": "AttributeError",
+     "evalue": "module 'math' has no attribute '__file__'",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_103570/2843878596.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnumpy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__file__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'matplotlib'"
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_275040/1949152461.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__file__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: module 'math' has no attribute '__file__'"
      ]
     }
    ],
    "source": [
     "print(math.__file__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some modules do not use the `__file__` attribute so you may get an error:\n",
+    "\n",
+    "``` python\n",
+    "AttributeError: module 'modulename' has no attribute '__file__'\n",
+    "```\n",
+    "\n",
+    "If this is the case `modulename.__spec__.origin` should give the same infomation."
    ]
   },
   {

--- a/notebooks/050import.ipynb
+++ b/notebooks/050import.ipynb
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -230,7 +230,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_275040/1949152461.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__file__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/tmp/ipykernel_280308/1949152461.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__file__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;31mAttributeError\u001b[0m: module 'math' has no attribute '__file__'"
      ]
     }
@@ -249,7 +249,24 @@
     "AttributeError: module 'modulename' has no attribute '__file__'\n",
     "```\n",
     "\n",
-    "If this is the case `modulename.__spec__.origin` should give the same infomation."
+    "If this is the case `print(modulename)` should give the same infomation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<module 'math' (built-in)>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(math)"
    ]
   },
   {

--- a/notebooks/050import.ipynb
+++ b/notebooks/050import.ipynb
@@ -249,7 +249,7 @@
     "AttributeError: module 'modulename' has no attribute '__file__'\n",
     "```\n",
     "\n",
-    "If this is the case `print(modulename)` should give the same infomation."
+    "If this is the case `print(modulename)` should display a description of the module object which will include an indication if the module is a 'built-in' module written in C (in which case the file path will not be specified) or the file path to the module otherwise."
    ]
   },
   {


### PR DESCRIPTION
Finding where a module's files have been stored using `module.__file__` fails on some systems. Added an alternative method - `print(module)`. Works on Ubuntu 20.04 with Python 3.8.10, might need to check at least one of these works on other systems.