### PR TITLE
Adding notebook introducing Matplotlib pyplot interface

### DIFF
--- a/notebooks/060MatplotlibPyplot.ipynb
+++ b/notebooks/060MatplotlibPyplot.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ad7b1f43-bfab-4759-993c-86103992ef5b",
+   "metadata": {},
+   "source": [
+    "# Plotting with Matplotlib - the `pyplot` interface\n",
+    "\n",
+    "[Matplotlib](https://matplotlib.org/) is a Python library which can be used to produce plots to visualise data. It has support for a wide range of [different plot types](https://matplotlib.org/stable/gallery/index.html), and as well as supporting static outputs it also allows producing [animations](https://matplotlib.org/stable/api/animation_api.html) and [interactive plots](https://matplotlib.org/stable/gallery/index.html#event-handling). As an intial introduction, we will demonstrate how to use Matplotlib's [`pyplot` interface](https://matplotlib.org/stable/api/index.html#the-pyplot-api) (modelled on the plotting functions in MATLAB), to create a simple line plot. If you return for our more advanced course we will illustrate Matplotlib's [object-oriented interface](https://matplotlib.org/stable/api/index.html#id3) which allows more flexibility in creating complex plots and greater control over the appearance of plot elements.\n",
+    "\n",
+    "## Importing Matplotlib\n",
+    "\n",
+    "We import the `pyplot` object from Matplotlib, which provides us with an interface for making figures. A common convention is to use the `import ... as ...` syntax to alias `matplotlib.pyplot` to the shorthand name `plt`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09312690-0cf8-4604-9ab1-77da6b0ee120",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1f54d9b-3057-4c3c-a589-36c55256ae21",
+   "metadata": {},
+   "source": [
+    "## A basic plot\n",
+    "\n",
+    "As a first example we create a basic line plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0acf2c1e-864e-4eba-9e8b-fd917f81f0aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot([2, 4, 6, 8, 10], [1, 5, 3, 7, -11])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed74a4bb-486b-4523-bb7f-3bddd18f859b",
+   "metadata": {},
+   "source": [
+    "The `plt.plot` function allows producing line and scatter plots which visualize the relationship between pairs of variables. Here we pass `plt.plot` two lists of five numbers corresponding to respectively the coordinates of the points to plot on the horizontal (*x*) axis and the coordinates of the points to plot on the vertical (*y*) axis. When passed no other arguments by default `plt.plot` will produce a line plot passing through the specified points. The value returned by `plt.plot` is a list of objects corresponding to the plotted line(s): in this case we plotted only one line so the list has only one element. We will for now ignore these return values until we cover object-oriented programminga and return to explain Matplotlib's object-oriented interface.\n",
+    "\n",
+    "If passed a single list of numbers, the `plt.plot` function will interpret these as the coordinates of the points to plot on the vertical (*y*) axis, with the horizontal (*x*) axis points in this case implicitly assumed to be the indices of the values in the list. For example, if we plot with just the second list from the previous `plt.plot` call"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b48bb38-c132-4535-8aa0-1358209fe2ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot([1, 5, 3, 7, -11])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83f08c97-bf38-43d2-b1cd-c5da1c32e862",
+   "metadata": {},
+   "source": [
+    "We get a very similar looking plot other than the change in the scale on the horizontal axis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "732ab315-3939-427b-b2b9-a92185765509",
+   "metadata": {},
+   "source": [
+    "## Plotting a function\n",
+    "\n",
+    "To make things a little more visually interesting, we will illustrate plotting the trigonometric functions *sine* ($\\sin$) and *cosine* ($\\cos$). We first import implementations of these functions from the in-built `math` module as well as the constant numerical constant `pi` ($\\pi$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40302d98-5cae-42b9-9b0e-ca0a85685bcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from math import sin, cos, pi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef27c7bd-132d-4ab8-a347-9d170db9fbed",
+   "metadata": {},
+   "source": [
+    "The `sin` and `cos` functions both take a single argument corresponding to an angular quantity in [radians](https://en.wikipedia.org/wiki/Radian) and are [periodic](https://en.wikipedia.org/wiki/Periodic_function) with period $2\\pi$. We therefore create a list of equally spaced angles in the interval $[0, 2\\pi)$ and assign it to a variable `theta`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fee6521-3786-4135-bb61-8f7eb0024cf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "number_of_points = 100\n",
+    "theta = [2 * pi * n / number_of_points for n in range(number_of_points)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62aa0910-483b-42c5-9639-77396ee8361e",
+   "metadata": {},
+   "source": [
+    "Using a list comprehension we can now compute the value of the sine function for each value in `theta` and graph this as the vertical coordinates of a line plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e74f4db-c8ba-43a5-8d27-66decb04703b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(theta, [sin(t) for t in theta])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36984f3b-0670-4fd2-9323-a3e226b21d08",
+   "metadata": {},
+   "source": [
+    "## Plotting multiple lines\n",
+    "\n",
+    "We can plot multiple different lines on the same plot by making mutiple calls to `plt.plot` within the same cell. For example in the cell below we compute both the sine and cosine functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50ea345c-248d-41ce-8dec-2c7d1a42fa6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(theta, [sin(t) for t in theta])\n",
+    "plt.plot(theta, [cos(t) for t in theta])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b7bc8cc-d334-4d8e-a520-5c143694bd68",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "By default Matplotlib will cycle through a [sequence of colours](https://matplotlib.org/stable/gallery/color/color_cycle_default.html) as each new plot is added to help distinguish between the different plotted lines.\n",
+    "\n",
+    "## Changing the line styles\n",
+    "\n",
+    "The `plt.plot` function offers various optional keyword arguments that can be used to further customise the plot. One useful argument is `linestyle` which allows the style of the line used to join the plotted points to be specified - for example this can useful to allow plotted lines to be distinguished even when they are printed in monochrome. Matplotlib as [a variety of built-in linestyles with simple string names](https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html) as well as options for performing further customisation. Here we specify for the cosine curve to be plotted with a dotted line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2153cdc-a6a2-44ae-a2b3-6bb32bd32a73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(theta, [sin(t) for t in theta])\n",
+    "plt.plot(theta, [cos(t) for t in theta], linestyle='dotted')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29603859-d524-4199-aeed-ab88c607bab5",
+   "metadata": {},
+   "source": [
+    "## Adding a legend\n",
+    "\n",
+    "Although we can visually distinguish between the two plotted lines, ideally we would have labels to indicate which corresponds to which function. We can add a legend to the plot with the `plt.legend` function. If we pass a list of strings to `plt.legend` these will be interpreted as the labels for each of the lines plotted so far in the order plotted. Matplotlib has [in-built support](https://matplotlib.org/stable/tutorials/text/mathtext.html) for using [TeX markup](https://en.wikibooks.org/wiki/LaTeX/Mathematics) to write mathematical expressions by putting the TeX markup within a pair of dollar signs (`$`). As TeX's use of the backslash character `\\` to prefix commands conflicts with Python's interpretation of `\\` as an escape character, you should typically use raw-strings by prefixing the string literal with `r` to simplify writing TeX commands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59798e22-62b8-4b28-86a4-21b1e6d9e2de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(theta, [sin(t) for t in theta])\n",
+    "plt.plot(theta, [cos(t) for t in theta], linestyle='dotted')\n",
+    "plt.legend([r'$\\sin\\theta$', r'$\\cos\\theta$'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99756f05-1a3c-4b64-a345-cb292201d25f",
+   "metadata": {},
+   "source": [
+    "Matplotlib also allows the legend label for a plot to be specified in the `plt.plot` call using the `label` keyword arugment. When plotting many lines this can be more readable than having to create a separate list of labels to pass to a subsequent `plt.legend` call. If we specify the `label` keyword arguments we can call `plt.legend` without any arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87a4c30f-d61d-4a2b-b4b1-89a4f735c90a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(theta, [sin(t) for t in theta], label=r'$f(\\theta) = \\sin\\theta$')\n",
+    "plt.plot(theta, [cos(t) for t in theta], linestyle='dotted', label=r'$f(\\theta) = \\cos\\theta$')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de76660e-e52a-44ea-8fa7-e87bf1eddc33",
+   "metadata": {},
+   "source": [
+    "## Adding axis labels and a title\n",
+    "\n",
+    "The `pyplot` interface also provides functions for adding axis labels and a title to our plot. Specifically `plt.xlabel` and `plt.ylabel` are functions which set the labels on respectively the horizontal (*x*) axis and vertical (*y*) axis, both accepting a string argument corresponding to the axis label. The `plt.title` function, as the name suggests, allows setting an overall title for the plot. As for the legend labels, the axis labels and title may all optionally use TeX mathematical notation delimited by dollar `$` signs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c667d057-5c21-4295-bc9b-c78cc26c79ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(theta, [sin(t) for t in theta], label=r'$f(\\theta) = \\sin\\theta$')\n",
+    "plt.plot(theta, [cos(t) for t in theta], linestyle='dotted', label=r'$f(\\theta) = \\cos\\theta$')\n",
+    "plt.legend()\n",
+    "plt.xlabel(r'Angle in radians $\\theta$')\n",
+    "plt.ylabel(r'$f(\\theta)$')\n",
+    "plt.title('Trigonometric functions')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
As discussed in meeting on 12/10/2021, this PR adds a new notebook introducing the basics of using Matplotlib via the command-based `pyplot` interface, for inclusion at the end of the beginner course. The intention is for the existing Matplotlib notebook / lesson to be updated to concentrate on the object-oriented interface (alongside potentially moving the ordering so that it is covered after the objected-oriented programming material) and more advanced usages of Matplotlib. The notebook being added here only covers the basics of creating a single axis line plot and adding a few additional key plot elements (legend, axis labels, title).