### PR TITLE
Adding Jekyll metadata to beginner course Matplotlib notebook

### DIFF
--- a/01-beginner/060MatplotlibPyplot.ipynb
+++ b/01-beginner/060MatplotlibPyplot.ipynb
@@ -244,6 +244,9 @@
   }
  ],
  "metadata": {
+  "jekyll": {
+   "display_name": "Plotting (i)"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",


### PR DESCRIPTION
Adds `jekyll` metadata field to the `01-beginner/060MatplotlibPyplot.ipynb` notebook that I believe is necessary for it to appear in the sidebar in the autogenerated HTML notes.

This was previously included as part of #29 but I've reverted the commit there and created a separate branch and PR to allow this to be reviewed and merged separately (as this is probably more urgent).