### PR TITLE
Add missing closing bracket and remove SciPy link

### DIFF
--- a/02-novice/index.md
+++ b/02-novice/index.md
@@ -5,7 +5,7 @@ title: Part II
 
 This is the second part of the *Introduction to research programming with Python* course
 
-This course introduces the basics of creating and interacting with scientific Python libraries such as [NumPy](https://numpy.org/, [SciPy](https://scipy.org/) and [Matplotlib](https://matplotlib.org/). If you are familiar with the basics of programming (variables, loops and functions) then this course offers you the next step – how to structure your code and organise it into modules.
+This course introduces the basics of creating and interacting with scientific Python libraries such as [NumPy](https://numpy.org/) and [Matplotlib](https://matplotlib.org/). If you are familiar with the basics of programming (variables, loops and functions) then this course offers you the next step – how to structure your code and organise it into modules.
 
 ### This session will cover:
 


### PR DESCRIPTION
In the changes I suggested as part of the review of #28 it looks like I forgot to include a closing bracket for the link the NumPy website. This PR also would remove the link and reference to SciPy as I don't think we ever directly use or discuss SciPy elsewhere?