### PR TITLE
Beginners notebook updates

### DIFF
--- a/01-beginner/015variables.ipynb
+++ b/01-beginner/015variables.ipynb
@@ -4,21 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Variables"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Variable Assignment"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When we generate a result, the answer is displayed, but not kept anywhere."
+    "# Variables\n",
+    "\n",
+    "## Variable assignment\n",
+    "\n",
+    "Python has built-in support for arithmetic expressions and so can be used as a calculator. When we evaluate an expression in Python, the result is displayed, but not necessarily stored anywhere."
    ]
   },
   {
@@ -27,14 +17,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "2 * 3"
+    "2 + 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "4 * 2.5"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we want to get back to that result, we have to store it. We put it in a box, with a name on the box. This is a **variable**."
+    "If we want to access the result in subsequent code, we have to store it. We put it in a box, with a name on the box. This is a _variable_. In Python we _assign_ a value to a variable using the _assignment operator_ `=`"
    ]
   },
   {
@@ -43,23 +42,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "six = 2 * 3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(six)"
+    "four = 2 + 2\n",
+    "four"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we look for a variable that hasn't ever been defined, we get an error. "
+    "As well as numeric [literal values](https://en.wikipedia.org/wiki/Literal_(computer_programming)) Python also has built in support for representing textual data as sequences of characters, which in computer science terminology are termed [_strings_](https://en.wikipedia.org/wiki/String_(computer_science)). Strings in Python are indicated by enclosing their contents in either a pair of single quotation marks `'...'` or a pair of double quotation marks `\"...\"`, for example"
    ]
   },
   {
@@ -68,14 +59,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(seven)"
+    "greeting = \"hello world\""
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That's **not** the same as an empty box, well labeled:"
+    "## Naming variables\n",
+    "\n",
+    "We can name variables with any combination of lower and uppercase characters, digits and underscores `_` providing the first character is not a digit and the name is not a [reserved keyword](https://docs.python.org/3/reference/lexical_analysis.html#keywords)."
    ]
   },
   {
@@ -84,7 +77,171 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nothing = None"
+    "fOuR = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "four_integer = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "integer_4 = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# invalid as name cannot begin with a digit\n",
+    "4_integer = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# invalid as for is a reserved word\n",
+    "for = 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is good practice to give variables descriptive and meaningful names to help make code self-documenting. As most modern development environments (including Jupyter Lab!) offer _tab completion_ there is limited disadvantage from a keystroke perspective of using longer  names. Note however that the names we give variables only have meaning to us:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two_plus_two = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## _Aside:_ Reading error messages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have already seen a couple of examples of Python error messages. It is important, when learning to program, to develop an ability to read an error message and find, from what can initially seem like confusing noise, the bit of the error message which tells you where the problem is.\n",
+    "\n",
+    "For example consider the following"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "number_1 = 1\n",
+    "number_2 = \"2\"\n",
+    "sum_of_numbers = number_1 + number_2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We may not yet know what `TypeError` or `Traceback` refer to. However, we can see that the error happens on the _third_ line of our code cell. We can also see that the error message: \n",
+    "\n",
+    "> `unsupported operand type(s) for +: 'int' and 'str'`\n",
+    " \n",
+    "...tells us something important. Even if we don't understand the rest, this is useful for debugging!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Undefined variables and `None` \n",
+    "\n",
+    "If we try to evaluate a variable that hasn't ever been defined, we get an error. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seven"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In Python names are case-sensitive so for example `six`, `Six` and `SIX` are all different variable names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "six = 6\n",
+    "six"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Six"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is a special `None` keyword in Python which can be assigned to variables to indicate a variable with no-value. This is _not_ the same as an undefined variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nothing = None\n",
+    "nothing"
    ]
   },
   {
@@ -100,7 +257,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(None is the special python value for a no-value variable.)"
+    "Anywhere we can use a literal value, we can instead use a variable name, for example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "5 + four * six"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scary = six * six * six\n",
+    "scary"
    ]
   },
   {
@@ -108,41 +284,7 @@
    "metadata": {},
    "source": [
     "*Supplementary Materials*: There's more on variables at \n",
-    "[Software Carpentry](http://swcarpentry.github.io/python-novice-inflammation/01-numpy/)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Anywhere we could put a raw number, we can put a variable label, and that works fine:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(5 * six)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scary = six * six * six"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(scary)"
+    "[Software Carpentry](https://swcarpentry.github.io/python-novice-inflammation/01-intro/index.html)."
    ]
   },
   {
@@ -156,7 +298,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But here's the real scary thing: it seems like we can put something else in that box:"
+    "We can reassign a variable - that is change what is in the box the variable labels."
    ]
   },
   {
@@ -165,37 +307,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scary = 25"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(scary)"
+    "scary = 25\n",
+    "scary"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that **the data that was there before has been lost**. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "No labels refer to it any more - so it has been \"Garbage Collected\"! We might imagine something pulled out of the box, and thrown on the floor, to make way for the next occupant."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In fact, though, it is the **label** that has moved. We can see this because we have more than one label refering to the same box:"
+    "The data that was previously labelled by the variable is lost. No labels refer to it any more - so it has been [_garbage collected_](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)). We might imagine something pulled out of the box, and disposed of, to make way for the next occupant. In reality, though, it is the _label_ that has moved. \n",
+    "\n",
+    "We can see this more clearly if we have more than one label referring to the same box"
    ]
   },
   {
@@ -204,67 +326,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"James\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nom = name"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(nom)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And we can move just one of those labels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nom = \"Hetherington\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "name = \"Grace Hopper\"\n",
+    "nom = name\n",
+    "print(name)\n",
     "print(nom)"
    ]
   },
@@ -272,40 +336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So we can now develop a better understanding of our labels and boxes: \n",
-    "each box is a piece of space (an *address*) in computer memory.\n",
-    "Each label (variable) is a reference to such a place."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When the number of labels on a box (\"variables referencing an address\") gets down to zero, then the data in the box cannot be found any more."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "After a while, the language's \"Garbage collector\" will wander by, notice a box with no labels, \n",
-    "and throw the data away, **making that box available for more data**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Old fashioned languages like C and Fortran don't have Garbage collectors. \n",
-    "So a memory address with no references to it still takes up memory, \n",
-    "and the computer can more easily run out."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "So when I write:"
+    "and we move just one of those labels:"
    ]
   },
   {
@@ -314,230 +345,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"Jim\""
+    "nom = \"Grace Brewster Murray Hopper\"\n",
+    "print(name)\n",
+    "print(nom)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following things happen:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "1. A new text **object** is created, and an address in memory is found for it.\n",
-    "1. The variable \"name\" is moved to refer to that address.\n",
-    "1. The old address, containing \"James\", now has no labels.\n",
-    "1. The garbage collector frees the memory at the old address."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Supplementary materials**: There's an online python tutor which is great for visualising memory and references. \n",
-    "Try the [scenario we just looked at](http://www.pythontutor.com/visualize.html#code=name+%3D+%22James%22%0Anom+%3D+name%0Aprint(nom%29%0Aprint(name%29%0Anom+%3D+%22Hetherington%22%0Aprint(nom%29%0Aprint(name%29%0Aname%3D+%22Jim%22%0Aprint(nom%29%0Aprint(name%29&mode=display&origin=opt-frontend.js&cumulative=false&heapPrimitives=true&textReferences=false&py=3&rawInputLstJSON=%5B%5D&curInstr=10)\n",
+    "## Variables and memory\n",
     "\n",
-    "Labels are contained in groups called \"frames\": our frame contains two labels, 'nom' and 'name'."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Objects and types"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "An object, like `name`, has a type. In the online python tutor example, we see that the objects have type \"str\".\n",
-    "`str` means a text object: Programmers call these 'strings'. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Depending on its type, an object can have different *properties*: data fields Inside the object."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Consider a Python complex number for example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z = 3 + 1j"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(z)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z.real"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z.imag"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = \"Banana\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x.real"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A property of an object is accessed with a dot."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The jargon is that the \"dot operator\" is used to obtain a property of an object."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When we try to access a property that doesn't exist, we get an error:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z.wrong"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Reading error messages."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It's important, when learning to program, to develop an ability to read an error message and find, from in amongst\n",
-    "all the confusing noise, the bit of the error message which tells you what to change!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We don't yet know what is meant by `AttributeError`, or \"Traceback\"."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "second_complex_number = 5 - 6j\n",
-    "print(\"Gets to here\")\n",
-    "print(second_complex_number.wrong)\n",
-    "print(\"Didn't get to here\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "But in the above, we can see that the error happens on the **third** line of our code cell."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can also see that the error message: \n",
-    "> 'complex' object has no attribute 'wrong' \n",
+    "We can now better understand our mental model of variables as labels and boxes: each box is a piece of space (an *address*) in computer memory. Each label (_variable_) is a reference to such a place and the data contained in the memory defines an _object_ in Python. Python objects come in different types - so far we have encountered both numeric (integer) and textual (string) types - more on this later.\n",
     "\n",
-    "...tells us something important. Even if we don't understand the rest, this is useful for debugging!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Variables and the notebook kernel"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When I type code in the notebook, the objects live in memory between cells."
+    "When the number of labels on a box (_variables referencing an address_) gets down to zero, then the data in the box cannot be accessed any more. This will trigger Python's garbage collector, which will then 'empty' the box (_deallocated the memory at the address_), making it available again to store new data.\n",
+    "\n",
+    "Lower-level languages such as C and Fortran do not have garbage collectors as a standard feature. So a memory address with no references to it and which has not been specifically marked as free remains unavailable for other usage, which can lead to difficult to fix [_memory leak_](https://en.wikipedia.org/wiki/Memory_leak) bugs.\n",
+    "\n",
+    "When we execute"
    ]
   },
   {
@@ -546,7 +371,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "number = 0"
+    "name = \"Grace Hopper\"\n",
+    "nom = name\n",
+    "nom = \"Grace Brewster Murray Hopper\"\n",
+    "name = \"Admiral Hopper\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "the following happens\n",
+    "\n",
+    "1. A new text (_string_) object `\"Grace Hopper\"` is created at a free address in memory and the variable `name` is set to refer to that address\n",
+    "2. The variable `nom` is set to refer to the object at the address referenced by `name`\n",
+    "3. A new text (_string_) object `\"Grace Brewster Murray Hopper\"` is created at a free address in memory and the variable `nom` is set to refer to that address\n",
+    "4. A new text (_string_) object `\"Admiral Hopper\"` is created at a free address in memory, the variable `name` is set to refer to that address and the garbage collector deallocates the memory used to hold `\"Grace Hopper\"` as this memory is no longer referenced by any variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_Supplementary materials_: The website [Python Tutor](https://pythontutor.com/) has a great interactive tool for visualizing how memory and references work in Python which is great for visualising memory and references. \n",
+    "Try the [scenario we just looked at](https://pythontutor.com/visualize.html#code=name%20%3D%20%22Grace%20Hopper%22%0Anom%20%3D%20name%0Anom%20%3D%20%22Grace%20Brewster%20Murray%20Hopper%22%0Aname%20%3D%20%22Admiral%20Hopper%22&cumulative=false&curInstr=4&heapPrimitives=true&mode=display&origin=opt-frontend.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variables in notebooks and kernels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When code cells are executed in a notebook, the variable names and values of the referenced objects persist between cells"
    ]
   },
   {
@@ -555,14 +417,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(number)"
+    "number = 1"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If I change a variable:"
+    "There if  we change a variable in one cell"
    ]
   },
   {
@@ -575,15 +437,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(number)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -591,33 +444,31 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "But cells are **not** always evaluated in order."
+    "number"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If I now go back to Input 22, reading `number = number + 1`, and run it again, with shift-enter. Number will change from 2 to 3, then from 3 to 4. Try it!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "So it's important to remember that if you move your cursor around in the notebook, it doesn't always run top to bottom."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Supplementary material**: \n",
-    "(1) [IPython documentation](http://ipython.readthedocs.io/)\n",
-    "(2) [Presentations about IPython](http://ipython.org/presentation.html)"
+    "In Jupyter terminology the Python process in which we run the code in a notebook in is termed a _kernel_. The _kernel_ stores the variable names and referenced objects created by any code cells in the notebook that have been previously run. The `Kernel` menu in the menu bar at the top of the JupyterLab interface has an option `Restart kernel...`. Running this will restart the kernel currently being used by the notebook, clearing any currently defined variables and returning the kernel to a 'clean' state. As you cannot restore a kernel once restarted a warning message is displayed asking you to confirm you wish to restart.\n",
+    "\n",
+    "## Cell run order\n",
+    "\n",
+    "Cells do **not** have to be evaluated in the order they appear in a notebook.\n",
+    "\n",
+    "If we go back to the code cell above with contents `number = number + 1`, and run it again, with <kbd>shift</kbd>+<kbd>enter</kbd> then `number` will change from 2 to 3, then from 3 to 4. Try it! \n",
+    "\n",
+    "However, running cells out of order like this can make it hard to keep track of what values are currently assigned to variables. It also makes it difficult to reproduce computations as getting the same output requires rerunning the cells in the same order, and it will not always be possible to reconstruct what the order used was. \n",
+    "\n",
+    "The number in square brackets in the prompt to the left of code cells, for example `[1]:` indicates the position in the overall cell run order of the last run of the cell. While this allows establishing if a cell last ran before or after another cell, if some cells are run multiple times then their previous run counter values will be overwritten so we lose information about the run order.\n",
+    "\n",
+    "In general if you are using notebooks in your own research you should try to make sure the notebook run and produce the desired outputs when the cells are executed sequentially from top to bottom. The `Kernel` menu provides an option to restart the current kernel and run all cells in order from top to bottom. If you just want to run a subset of the cells there is also an option to restart and run all cells from the top to the currently selected cell. The commands are useful for checking that a notebook will produce the expected output and run without errors when the cells are executed in order."
    ]
   }
  ],
@@ -627,7 +478,7 @@
    "display_name": "Variables"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -641,9 +492,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/01-beginner/016using_functions.ipynb
+++ b/01-beginner/016using_functions.ipynb
@@ -254,7 +254,7 @@
    "source": [
     "## Functions are objects\n",
     "\n",
-    "A powerful feature of Python (and one that can take a little while to wrap your head around) is that functions are just a particular type of object and so can be for example assigned to variables or passed as arguments to other functions. We have in fact already seen examples of this when using the `help` function, with we passing a function as the (only) argument to `help`. We can also assign functions to variables"
+    "A powerful feature of Python (and one that can take a little while to wrap your head around) is that functions are just a particular type of object and so can be for example assigned to variables or passed as arguments to other functions. We have in fact already seen examples of this when using the `help` function, with a function passed as the (only) argument to `help`. We can also assign functions to variables"
    ]
   },
   {

--- a/01-beginner/016using_functions.ipynb
+++ b/01-beginner/016using_functions.ipynb
@@ -2,23 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "# Using Functions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Calling functions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We often want to do thing to our objects that are more complicated than just assigning them to variables."
+    "# Using functions\n",
+    "\n",
+    "Functions in Python (and other programming languages) are modular units of code which specify a set of instructions to perform when the function is _called_ in code. Functions may take one or more input values as _arguments_ and may _return_ an output value. Functions can also have _side-effects_ such as printing information to a display. \n",
+    "\n",
+    "## Calling functions in Python\n",
+    "\n",
+    "Python provides a range of useful [built-in functions](https://docs.python.org/3/library/functions.html) for performing common tasks. For example the `len` function returns the length of a sequence object (such as a string) passed as input argument. To _call_ a function in Python we write the name of the function followed by a pair of parentheses `()`, with any arguments to the function being put inside the parentheses:"
    ]
   },
   {
@@ -31,40 +25,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len([3, 5, 15])"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we have \"called a function\"."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The function `len` takes one input, and has one output. The output is the length of whatever the input was."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Programmers also call function inputs \"parameters\" or, confusingly, \"arguments\"."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here's another example:"
+    "If a function can accept more than one argument they are separated by commas. For example the built-in `max` function when passed a pair of numeric arguments returns the larger value from the pair:"
    ]
   },
   {
@@ -73,28 +37,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sorted(\"Python\")"
+    "max(1, 5)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Which gives us back a *list* of the letters in Python, sorted alphabetically."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The input goes in brackets after the function name, and the output emerges wherever the function is used."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "So we can put a function call anywhere we could put a \"literal\" object or a variable. "
+    "Another built-in function which we have already seen several times is `print`. Unlike `len` and `max`, `print` does not have an explicit return value as its purpose is to print a string representation of the argument(s) to a text display such as the output area of a notebook code cell. For functions like `print` which do not have an explicit return value, the special null value `None` we encountered previously will be used as the value of a call to the function if used in an expression or assigned to a variable:"
    ]
   },
   {
@@ -103,7 +53,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"Jim\""
+    "return_value = print(\"Hello\")\n",
+    "print(return_value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Function calls can be placed anywhere we can use a literal value or a variable name, for example"
    ]
   },
   {
@@ -112,6 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "name = \"Jim\"\n",
     "len(name) * 8"
    ]
   },
@@ -121,142 +80,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = len(\"Mike\")\n",
-    "y = len(\"Bob\")\n",
-    "z = x + y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(z)"
+    "total_length = len(\"Mike\") + len(\"Bob\")\n",
+    "print(total_length)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using methods"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Objects come associated with a bunch of functions designed for working on objects of that type. We access these with a dot, just as we do for data attributes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"shout\".upper()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"WhiSpER\".lower()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "These are called methods. If you try to use a method defined for a different type, you get an error:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = 5\n",
-    "x.upper()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you try to use a method that doesn't exist, you get an error:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = 5\n",
-    "x.wrong"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Methods and properties are both kinds of **attribute**, so both are accessed with the dot operator."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Objects can have both properties and methods:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z = 1 + 5j"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z.real"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z.conjugate()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Functions are just a type of object!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now for something that will take a while to understand: don't worry if you don't get this yet, we'll\n",
-    "look again at this in much more depth later in the course.\n",
+    "## Getting help on functions\n",
     "\n",
-    "If we forget the (), we realise that a *method is just a property which is a function*!"
+    "The built-in `help` function, when passed a function, prints documentation for the function, which typically includes a description of the what arguments can be passed and what the function returns. For example"
    ]
   },
   {
@@ -265,41 +99,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "z.conjugate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(z.conjugate)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "somefunc = z.conjugate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "somefunc()"
+    "help(max)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Functions are just a kind of variable:"
+    "In Jupyter notebooks an alternative way of displaying the documentation for a function is to write the function names followed by a question mark character `?`"
    ]
   },
   {
@@ -308,221 +115,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "magic = sorted"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(magic)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "magic([\"Technology\", \"Advanced\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def double(data):\n",
-    "    return data * 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "double(5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "double"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "timestwo = double"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "timestwo(8)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "timestwo(5, 6, 7)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def timesten(input):\n",
-    "    return 5 * double(input)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "timesten(4)"
+    "max?"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getting help on functions and methods"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The 'help' function, when applied to a function, gives help on it!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "help(sorted)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "help(z.conjugate)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The 'dir' function, when applied to an object, lists all its attributes (properties and methods):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dir(\"Hexxo\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Most of these are confusing methods beginning and ending with __, part of the internals of python."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Again, just as with error messages, we have to learn to read past the bits that are confusing, to the bit we want:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"Hexxo\".replace(\"x\", \"l\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Operators"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now that we know that functions are a way of taking a number of inputs and producing an output, we should look again at\n",
-    "what happens when we write:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = 2 + 3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is just a pretty way of calling an \"add\" function. Things would be more symmetrical if add were actually written\n",
+    "## Positional and keyword arguments and default values\n",
     "\n",
-    "    x = +(2,3)\n",
-    "    \n",
-    "Where '+' is just the name of the name of the adding function."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In python, these functions **do** exist, but they're actually **methods** of the first input: they're the mysterious `__` functions we saw earlier (Two underscores.)"
+    "There are two ways of passing arguments to function in Python. In the examples so far the function arguments have only been identified by the position they appear in the argument list of the function. An alternative is to use named or _keyword_ arguments, by prefixing some or all of the arguments with the argument name followed by an equals sign. For example, there is a built-in function `round` which rounds decimal numbers to a specified precision. Using the `help` function we can read the documentation for `round` to check what arguments it accepts\n"
    ]
   },
   {
@@ -531,21 +133,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x.__add__(7)"
+    "help(round)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We call these symbols, `+`, `-` etc, \"operators\"."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The meaning of an operator varies for different types:"
+    "We see that `round` accepts two arguments, a `number` argument which specifies the number to round and a `ndigits` argument which specifies the number of decimal digits to round to. One way to call `round` is by passing positional arguments in the order specified in function signature `round(number, ndigits=None)` with the first argument corresponding to `number` and the second `ndigits`. For example"
    ]
   },
   {
@@ -554,14 +149,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[2, 3, 4] + [5, 6]"
+    "pi = 3.14159265359\n",
+    "round(pi, 2)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sometimes we get an error when a type doesn't have an operator:"
+    "To be more expicit about which parameters of the function the arguments we are passing correspond to, we can instead however pass the arguments by name (as _keyword arguments_)"
    ]
   },
   {
@@ -570,7 +166,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "7 - 2"
+    "round(number=pi, ndigits=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can in-fact mix and match position and keyword arguments, _providing that all keyword arguments come after any positional arguments_"
    ]
   },
   {
@@ -579,21 +182,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[2, 3, 4] - [5, 6]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The word \"operand\" means \"thing that an operator operates on\"!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or when two types can't work together with an operator:"
+    "round(pi, ndigits=2)"
    ]
   },
   {
@@ -602,14 +191,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "[2, 3, 4] + 5"
+    "round(number=pi, 2)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just as in Mathematics, operators have a built-in precedence, with brackets used to force an order of operations:"
+    "Unlike positional arguments the ordering of keyword arguments does not matter so for example the following is also valid and equivalent to the calls above"
    ]
   },
   {
@@ -618,7 +207,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(2 + 3 * 4)"
+    "round(ndigits=2, number=pi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the documentation for `round` we see that the second argument in the function signature is written `ndigits=None`. This indicates that `ndigits` is an _optional_ argument which takes the default value `None` if it is not specified. The documentation further states that\n",
+    "\n",
+    "> The return value is an integer if `ndigits` is omitted or `None`  \n",
+    "\n",
+    "which indicates that when `ndigits` is left as its default value (that is the argument is omitted or explicitly set to `None`) the `round` function returns the value of `number` rounded to the nearest integer. The following are all equivalent therefore"
    ]
   },
   {
@@ -627,14 +227,69 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print((2 + 3) * 4)"
+    "round(pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "round(number=pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "round(number=pi, ndigits=None)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Supplementary material*: [Python operator precedence](http://www.mathcs.emory.edu/~valerie/courses/fall10/155/resources/op_precedence.html)"
+    "## Functions are objects\n",
+    "\n",
+    "A powerful feature of Python (and one that can take a little while to wrap your head around) is that functions are just a particular type of object and so can be for example assigned to variables or passed as arguments to other functions. We have in fact already seen examples of this when using the `help` function, with we passing a function as the (only) argument to `help`. We can also assign functions to variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_print = print\n",
+    "my_print"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(my_print)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_print(\"Hello\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While giving function aliases like this may not seem particularly useful at the moment, we will see that the ability to pass functions to other functions and assign functions to variables can be very useful in certain contexts."
    ]
   }
  ],
@@ -644,7 +299,7 @@
    "display_name": "Using Functions"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -658,9 +313,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/01-beginner/023types.ipynb
+++ b/01-beginner/023types.ipynb
@@ -11,7 +11,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have seen that Python objects have a 'type':"
+    "We have so far encountered several different 'types' of Python object: \n",
+    "\n",
+    "- integer numbers, for example `42`, \n",
+    "- real numbers, for example `3.14`,\n",
+    "- strings, for example `\"abc\"`,\n",
+    "- functions, for example `print`,\n",
+    "- the special 'null'-value `None`. \n",
+    "\n",
+    "The built-in function `type` when passed a single argument will return the type of the argument object. For example"
    ]
   },
   {
@@ -20,7 +28,319 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "type(5)"
+    "type(42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(\"abc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Converting between types\n",
+    "\n",
+    "The Python type names such as `int` (integer numbers) and `str` (strings) can be used like functions to construct _instances_ of the type, typically by passing an object of another type which can be converted to the type being called. For example we can use `int` to convert a string of digits to an integer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int(\"123\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int(\"2\") + int(\"2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or to convert a real number to an integer (in this case by truncating off the decimal part)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int(2.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Conversely we can use `str` to convert numbers to strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "str(123)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "str(3.14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Object attributes and methods\n",
+    "\n",
+    "Objects in Python have _attributes_: named values associated with the object and which are referenced to using the dot operator `.` followed by the attribute name, for example `an_object.attribute` would access (if it exists) the attribute named `attribute` of the object `an_object`. Each type has a set of pre-defined attributes. \n",
+    "\n",
+    "Object attributes can reference arbitrary data associated with the object, or special functions termed _methods_ which have access to both any argument passed to them _and_ any other attributes of the object, and which are typically used to implement functionality connected to a particular object type.\n",
+    "\n",
+    "For example the `float` type used by Python to represent non-integer numbers (more on this in a bit) has attribute `real` and `imaginary` which can be used to access the real and imaginary components when considering the value as a [complex number](https://en.wikipedia.org/wiki/Complex_number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_number = 12.5\n",
+    "print(a_number.real)\n",
+    "print(a_number.imag)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Objects of `str` type (strings) have methods `upper` and `lower` which both take no arguments, and respectively return the string in all upper case or all lower case characters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_string = \"Hello world!\"\n",
+    "print(a_string.upper())\n",
+    "print(a_string.lower())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you try to access an attribute not defined for a particular type you will get an error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_string.real"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_number.upper()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can list all of the attributes of an object by passing the object to the built-in `dir` function, for example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dir(a_string))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The attributes with names beginning and ending in double underscores `__` are special methods that implement the functionality associated with applying operators (and certain built-in functions) to objects of that type, and are generally not accessed directly.\n",
+    "\n",
+    "In Jupyter notebooks we can also view an objects properties using tab-completion by typing the object name followed by a dot `.` then hitting <kbd>tab</kbd>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Operators\n",
+    "\n",
+    "Now that we know more about types, functions and methods we should look again at what happens when we write:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "four = 2 + 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The addition symbol `+` here is an example of what is termed an _operator_, in particular `+` is a _binary operator_ as it applies to pairs of values.\n",
+    "\n",
+    "We can think of the above code as equivalent to something like\n",
+    "\n",
+    "```Python\n",
+    "    four = add(2, 2)\n",
+    "```\n",
+    "\n",
+    "where `add` is the name of a function which takes two arguments and returns their sum.\n",
+    "\n",
+    "In Python, these functions _do_ exist, but they're actually _methods_ of the first input: they're the mysterious double-underscore `__` surrounded attributes we saw previously. For example the addition operator `+` is associated with a special method `__add__`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two = 2\n",
+    "two.__add__(two)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The meaning of an operator varies for different types. For example for strings the addition operator `+` implements string concatenation (joining)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"Hello\" + \" \" + \"world\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"2\" + \"2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes we get an error when a type doesn't have an operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"Hello\" - \"world\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The word \"operand\" means \"thing that an operator operates on\"!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or when two types can't work together with an operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"2\" + 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just as in mathematics, operators in Python have a built-in precedence, with brackets used to force an order of operations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(2 + 3 * 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print((2 + 3) * 4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Supplementary material*: [Python operator precedence](https://docs.python.org/3/reference/expressions.html#operator-precedence)"
    ]
   },
   {
@@ -34,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Python has two core numeric types, `int` for integer, and `float` for real number."
+    "Python has two core numeric types, `int` for integers, and `float` for real numbers."
    ]
   },
   {
@@ -43,62 +363,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "one = 1\n",
-    "ten = 10\n",
-    "one_float = 1.0\n",
-    "ten_float = 10."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tenth = one_float / ten_float"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tenth"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "one // ten"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "2 + 3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"Hello \" + \"World\""
+    "integer_one = 1\n",
+    "integer_ten = 10\n",
+    "float_one = 1.0\n",
+    "float_ten = 10."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With integers, we can be clear about what we want: divide an integer by an integer and return another integer, or divide an integer by an integer and return a floating point. Most other languages do not afford that kind of distinction! It can lead to hard-to-find bugs."
+    "Binary arithmetic operators applied to objects of `float` and `int` types will return a `float`"
    ]
   },
   {
@@ -107,7 +382,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(one // ten, one / ten)"
+    "integer_one * float_ten"
    ]
   },
   {
@@ -116,14 +391,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(type(one // ten), type(one / tenth))"
+    "float_one + integer_one"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The divided by operator `/` means divide by for real numbers. Whereas `//` means divide by integers for integers, and divide by floats for floats"
+    "In Python there are two division operators `/` and `//` which implement different mathematical operations. The _true division_ (or just _division_) operator `/` implements what we usually think of by division, such that for two `float` values `x` and `y` `z = x / y` is another `float` values such that `y * z` is (to within machine precision) equal to `x`. The _floor division_ operator `//` instead implements the operation of dividing and rounding down to the nearest integer."
    ]
   },
   {
@@ -132,7 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "10 // 3"
+    "float_one / float_ten"
    ]
   },
   {
@@ -141,7 +416,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "10 / 3"
+    "float_one / integer_ten"
    ]
   },
   {
@@ -150,7 +425,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "10 // 3.0"
+    "float_one // float_ten"
    ]
   },
   {
@@ -159,7 +434,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "str(5)"
+    "integer_one // integer_ten"
    ]
   },
   {
@@ -168,53 +443,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "10 / float(3)"
+    "integer_one // float_ten"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "x = 5"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "str(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = \"5.2\"\n",
+    "In reality the `float` type does not exactly represent real numbers (as being able to represent all real numbers to arbitrary precision is impossible in a object with uses a finite amount of memory) but instead represents real-numbers as a finite-precision 'floating-point' approximation. This has many important implications for the implementation of numerical algorithms. We will not have time to cover this topic here but the following resources can be used to learn more for those who are interested.\n",
     "\n",
-    "int(float(x))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "I lied when I said that the `float` type was a real number. It's actually a computer representation of a real number\n",
-    "called a \"floating point number\". Representing $\\sqrt 2$ or $\\frac{1}{3}$ perfectly would be impossible in a computer, so we use a finite amount of memory to do it."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "*Supplementary material*:\n",
     "\n",
-    "* [Python and floating point](https://docs.python.org/3.6/tutorial/floatingpoint.html)\n",
+    "* [Floating point arithmetic in Python](https://docs.python.org/3/tutorial/floatingpoint.html)\n",
     "* [Floating point guide](http://floating-point-gui.de/formats/fp/)\n",
     "* Advanced: [What Every Computer Scientist Should Know About Floating-Point Arithmetic](http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html)"
    ]
@@ -230,8 +470,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Python has a built in `string` type, supporting many\n",
-    "useful methods."
+    "Python built-in `string` type, supports many useful operators and methods. As we have seen already the addition operator can be used to concatenate strings"
    ]
   },
   {
@@ -240,8 +479,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "given = \"James\"\n",
-    "family = \"Hetherington\"\n",
+    "given = \"Grace\"\n",
+    "family = \"Hopper\"\n",
     "full = given + \" \" + family"
    ]
   },
@@ -249,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So `+` for strings means \"join them together\" - *concatenate*."
+    "The multiplication operator `*` can be used to repeat strings"
    ]
   },
   {
@@ -258,23 +497,47 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\"Badger \" * 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Methods such as `upper` and `lower` can be used to alter the case of the string characters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(full.lower())\n",
     "print(full.upper())"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `replace` method can be used to replace characters"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "2 * 4"
+    "full.replace(\"c\", \"p\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As for `float` and `int`, the name of a type can be used as a function to convert between types:"
+    "The `count` method can be used to count the occurences of particular characters in the string"
    ]
   },
   {
@@ -283,59 +546,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ten"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "one"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(ten)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(ten + one)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(float(str(ten) + str(one)))"
+    "full.count(\"p\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can remove extraneous material from the start and end of a string:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "5"
+    "We can use `strip` to remove extraneous whitespace from the start and end of a string:"
    ]
   },
   {
@@ -346,330 +564,6 @@
    "source": [
     "\"    Hello  \".strip()"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Lists"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Python's basic **container** type is the `list`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can define our own list with square brackets:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[1, 3, 7]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type([1, 3, 7])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Lists *do not* have to contain just one type:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "various_things = [1, 2, \"banana\", 3.4, [1, 2]]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We access an **element** of a list with an `int` in square brackets:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "one = 1\n",
-    "two = 2\n",
-    "three = 3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "my_new_list = [one, two, three]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "middle_value_in_list = my_new_list[1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "middle_value_in_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[1, 2, 3][1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "various_things[2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "index = 2\n",
-    "various_things[index]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that list indices start from zero."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can quickly make a list with numbers counted up:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "count_to_five = list(range(5))\n",
-    "print(count_to_five)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can use a string to join together a list of strings:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "name = [\"James\", \"Philip\", \"John\", \"Hetherington\"]\n",
-    "print(\" -> \".join(name))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And we can split up a string into a list:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"Ernst Stavro Blofeld\".split(\"o\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can an item to a list:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "name.append(\"Jr\")\n",
-    "print(name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or we can add more than one:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "name.extend([\"the\", \"third\"])\n",
-    "print(name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Sequences"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Many other things can be treated like `lists`. Python calls things that can be treated like lists `sequences`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A string is one such *sequence type*"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(count_to_five[1])\n",
-    "print(\"James\"[2])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(count_to_five[1:3])\n",
-    "print(\"Hello World\"[4:8])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(len(various_things))\n",
-    "print(len(\"Python\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len([[1, 2], 4])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"John\" in name)\n",
-    "print(9 in count_to_five)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Unpacking"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Multiple values can be **unpacked** when assigning from sequences, like dealing out decks of cards."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mylist = [\"Goodbye\", \"Cruel\"]\n",
-    "a, b = mylist\n",
-    "print(a)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a = mylist[0]\n",
-    "b = mylist[1]"
-   ]
   }
  ],
  "metadata": {
@@ -677,7 +571,7 @@
    "display_name": "Types"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -691,9 +585,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/01-beginner/023types.ipynb
+++ b/01-beginner/023types.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "or to convert a real number to an integer (in this case by truncating off the decimal part)"
+    "or to convert a decimal number to an integer (in this case by truncating off the decimal part)"
    ]
   },
   {

--- a/01-beginner/025containers.ipynb
+++ b/01-beginner/025containers.ipynb
@@ -9,9 +9,342 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Lists"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Checking for containment."
+    "Python's basic **container** type is the `list`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can define our own list with square brackets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[1, 3, 7]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type([1, 3, 7])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lists *do not* have to contain just one type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "various_things = [1, 2, \"banana\", 3.4, [1, 2]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We access an **element** of a list with an `int` in square brackets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one = 1\n",
+    "two = 2\n",
+    "three = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_new_list = [one, two, three]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "middle_value_in_list = my_new_list[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "middle_value_in_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[1, 2, 3][1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "various_things[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 2\n",
+    "various_things[index]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that list indices start from zero."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can quickly make a list containing a range of consecutive integer numbers using the built-in `range` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count_to_five = list(range(5))\n",
+    "print(count_to_five)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use a string to join together a list of strings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = [\"Grace\", \"Brewster\", \"Murray\", \"Hopper\"]\n",
+    "print(\" \".join(name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can split up a string into a list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"Ernst Stavro Blofeld\".split(\" \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can an item to a list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name.append(\"BA\")\n",
+    "print(\" \".join(name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can add more than one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name.extend([\"MS\", \"PhD\"])\n",
+    "print(\" \".join(name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or insert values at different points in the list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name.insert(0, \"Admiral\")\n",
+    "print(\" \".join(name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sequences"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Many other things can be treated like `lists`. Python calls things that can be treated like lists _sequences_."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A string is one such *sequence type*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(count_to_five[1])\n",
+    "print(\"James\"[2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(count_to_five[1:3])\n",
+    "print(\"Hello World\"[4:8])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(various_things))\n",
+    "print(len(\"Python\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len([[1, 2], 4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Unpacking"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Multiple values can be **unpacked** when assigning from sequences, like dealing out decks of cards."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mylist = [\"Goodbye\", \"Cruel\"]\n",
+    "a, b = mylist\n",
+    "print(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = mylist[0]\n",
+    "b = mylist[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Checking for containment"
    ]
   },
   {
@@ -78,10 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "An array can be modified:\n",
-    "\n",
-    "\n"
+    "An list can be modified:"
    ]
   },
   {
@@ -90,7 +420,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"James Philip John Hetherington\".split(\" \")\n",
+    "name = \"Grace Brewster Murray Hopper\".split(\" \")\n",
     "print(name)"
    ]
   },
@@ -100,8 +430,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name[0] = \"Dr\"\n",
-    "name[1:3] = [\"Griffiths-\"]\n",
+    "name[0:3] = [\"Admiral\"]\n",
     "name.append(\"PhD\")\n",
     "\n",
     "print(\" \".join(name))"
@@ -349,7 +678,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Identity vs Equality\n",
+    "## Identity versus equality\n",
     "\n",
     "\n",
     "Having the same data is different from being the same actual object\n",
@@ -370,7 +699,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The == operator checks, element by element, that two containers have the same data. \n",
+    "The `==` operator checks, element by element, that two containers have the same data. \n",
     "The `is` operator checks that they are actually the same object."
    ]
   },
@@ -406,7 +735,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But, and this point is really subtle, for immutables, the python language might save memory by reusing a single instantiated copy. This will always be safe."
+    "But, and this point is really subtle, for immutables, the Python language might save memory by reusing a single instantiated copy. This will always be safe."
    ]
   },
   {
@@ -426,7 +755,7 @@
    "display_name": "Containers"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -440,9 +769,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/01-beginner/025containers.ipynb
+++ b/01-beginner/025containers.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Containers"
+    "# Containers\n",
+    "\n",
+    "Containers are a data type that _contains_ other objects."
    ]
   },
   {
@@ -755,7 +757,7 @@
    "display_name": "Containers"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -769,7 +771,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates to the notebooks performed before last run of 'beginner' course in January / February 2022

  * More detailed added to `015variables.ipynb` to try to make it more self-contained and some extra links to supplementary material and expanded note on how run order of cells in Jupyter notebook can lead to difficulties in understanding state.
  * Updated ordering of material in `016using_functions.ipynb`, `023types.ipynb` and `024containers.ipynb` to try to make the flow a bit more logical. The material on operators and methods is now moved to after introducing the basic ideas of types in Python and description of accessing attributes of Python objects with dot syntax. The material on lists has been moved out from types notebook to beginning of containers notebook and the repetition of the introduction of the `in` operator for lists and then other types separately removed.