### PR TITLE
Fixing Unicode encoding error when running on Windows

### DIFF
--- a/02-novice/020TabularData.ipynb
+++ b/02-novice/020TabularData.ipynb
@@ -329,7 +329,7 @@
     "    ['Neptune', 30., 170., 17., 3.9, 14],\n",
     "]\n",
     "\n",
-    "with open('planets_data.csv', 'w') as f:\n",
+    "with open('planets_data.csv', 'w', encoding='utf-8') as f:\n",
     "    csv_writer = csv.writer(f, delimiter=',')\n",
     "    for row in planets_data:\n",
     "        csv_writer.writerow(row)"


### PR DESCRIPTION
Explicitly sets encoding to UTF-8 of file opened to save solar system data in CSV format at end of tabular data notebook to avoid `UnicodeEncodeError` being raised on Windows (which seems to default to [CP-1252](https://en.wikipedia.org/wiki/Windows-1252) encoding by default).