### PR TITLE
Include exemplar data in distribution zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ notes.pdf: combined.ipynb Makefile
 	mv combined.pdf notes.pdf
 
 notebooks.zip: ${NBV2}
-	zip -r notebooks $^
+	zip -r notebooks $^ 01-beginner/data/*
 
 .PHONY: ready
 


### PR DESCRIPTION
For #43, although does not address the question of whether the directory should be removed with `make clean`.

Have checked locally that this adds the files in the zip with no other apparent differences.