### PR TITLE
Updating material in dictionaries notebook

### DIFF
--- a/01-beginner/028dictionaries.ipynb
+++ b/01-beginner/028dictionaries.ipynb
@@ -4,35 +4,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dictionaries"
+    "# Dictionaries and sets\n",
+    "\n",
+    "In addition to lists and tuples, two other container types in Python that is useful to be aware of are _dictionaries_ and _sets_."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The Python Dictionary"
+    "## Dictionaries\n",
+    "\n",
+    "Python has built-in support for a `dict` container type (short for _dictionary_), with similar types sometimes known as an _associative array_, _map_ or _hash (table)_ in other languages."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Python supports a container type called a dictionary."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is also known as an \"associative array\", \"map\" or \"hash\" in other languages."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In a list, we use a number to look up an element:"
+    "In a list, we use an integer index to look up an element, and we can think of lists as maps from integer indices to the corresponding list element:"
    ]
   },
   {
@@ -41,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "names = \"Martin Luther King\".split(\" \")\n",
+    "names = [\"Martin\", \"Luther\", \"King\"]\n",
     "names[1]"
    ]
   },
@@ -49,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In a dictionary, we look up an element using **another object of our choice**:"
+    "A dictionary on the other hand allows creating maps in which we look up elements using objects of much more general types, for example strings:"
    ]
   },
   {
@@ -58,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "me = {\"name\": \"James\", \"age\": 39, \"Jobs\": [\"Programmer\", \"Teacher\"]}"
+    "person = {\"name\": \"James\", \"age\": 39, \"Jobs\": [\"Programmer\", \"Teacher\"]}"
    ]
   },
   {
@@ -67,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(me)"
+    "print(person)"
    ]
   },
   {
@@ -76,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(me[\"Jobs\"])"
+    "print(person[\"Jobs\"])"
    ]
   },
   {
@@ -85,21 +75,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(type(me))"
+    "print(type(person))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Keys and Values"
+    "### Keys and values"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The things we can use to look up with are called **keys**:"
+    "The set of objects we use to look up the elements in a dictionary are called **keys**. The `keys` method of a dictionary can be used to extract the collection of all keys in the dictionary:"
    ]
   },
   {
@@ -108,14 +98,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "me.keys()"
+    "person.keys()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The things we can look up are called **values**:"
+    "The objects associated with they keys in a dictionary (the things we look up) are called **values**. The `values` method of a dictionary returns the collection of all values in the dictionary:"
    ]
   },
   {
@@ -124,14 +114,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "me.values()"
+    "person.values()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When we test for containment on a `dict` we test on the **keys**:"
+    "Dictionaries also define an `items` method which can be used to access the collection of all key-value pairs in the dictionary:"
    ]
   },
   {
@@ -140,7 +130,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"Jobs\" in me"
+    "person.items()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A peculiarity of dictionaries in Python is that when we test for _containment_, we test on the key:"
    ]
   },
   {
@@ -149,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"James\" in me"
+    "\"Jobs\" in person"
    ]
   },
   {
@@ -158,24 +155,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"James\" in me.values()"
+    "\"James\" in person"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Immutable Keys Only"
+    "To check for whether a dictionary contains a certain value we therefore need to use the `values` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"James\" in person.values()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "The way in which dictionaries work is one of the coolest things in computer science:\n",
-    "the \"hash table\". This is way beyond the scope of this course, but it has a consequence:\n",
+    "### Missing keys and safe lookup\n",
     "\n",
-    "You can only use **immutable** things as keys."
+    "If we try to look up a key not contained in a dictionary we will get an error:"
    ]
   },
   {
@@ -184,14 +191,80 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "good_match = {(\"Lamb\", \"Mint\"): True, (\"Bacon\", \"Chocolate\"): False}"
+    "x = {\"a\": 1, \"b\": 2}\n",
+    "print(x[\"a\"])\n",
+    "print(x[\"fish\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "but:"
+    "To allow safely looking up keys which might not be defined, dictionaries provide a `get` method which takes a single argument corresponding to the key to lookup and returns the value associated with the key if present in the dictionary, and the special `None` value otherwise"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(x.get(\"a\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(x.get(\"fish\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `get` method can also be called with an optional second argument which is used inplace of `None` as the default value returned if the key is not present in the dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x.get(\"fish\", \"tuna\") == \"tuna\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hashable keys only"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dictionaries in Python are implemented using a data structure called a [_hash table_](https://en.wikipedia.org/wiki/Hash_table#In_programming_languages). The details of how hash tables work is beyond the scope of this course work, but it has a consequence: only [_hashable_](https://docs.python.org/3/glossary.html#term-hashable) objects can be used as keys in dictionaries. Immutable basic types (such as `int`, `float`, `str`) and immutable containers (such as tuples) _which contain only immutable objects_ are hashable and can be used as dictionaries keys. So for example defining a dictionary with keys which are tuples of strings works:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "good_match = {(\"Salt\", \"Pepper\"): True, (\"Vinegar\", \"Chocolate\"): False}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "but using lists as keys doesn't:"
    ]
   },
   {
@@ -207,36 +280,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Supplementary material*: You can start to learn about [the 'hash table'](https://www.youtube.com/watch?v=h2d9b_nEzoA). Though this video is **very** advanced I think it's really interesting!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## No guarantee of order"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Another consequence of the way dictionaries work is that there's no guaranteed order among the\n",
-    "elements:\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "my_dict = {\"0\": 0, \"1\": 1, \"2\": 2, \"3\": 3, \"4\": 4}\n",
-    "print(my_dict)\n",
-    "print(my_dict.values())"
+    "*Supplementary material*: If you wish to learn more about hash tables [this YouTube video](https://www.youtube.com/watch?v=h2d9b_nEzoA) gives a comprehensive (but quite advanced) overview."
    ]
   },
   {
@@ -250,7 +294,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A set is a `list` which cannot contain the same element twice."
+    "A set is a container which cannot contain the same element twice."
    ]
   },
   {
@@ -260,25 +304,17 @@
    "outputs": [],
    "source": [
     "university = \"University College London\"\n",
-    "unique_letters = set(university)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "unique_letters = set(university)\n",
     "unique_letters"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "print(\"\".join(unique_letters))"
+    "### Ordering\n",
+    "\n",
+    "Sets are _unordered_ collections, for example there are no guarantees over the order in which items in the set will be printed:"
    ]
   },
   {
@@ -287,14 +323,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\".join([\"a\", \"b\", \"c\"])"
+    "print(unique_letters)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It has no particular order, but is really useful for checking or storing **unique** values."
+    "### Checking uniqueness\n",
+    "\n",
+    "Sets are particular useful for checking or storing **unique** values."
    ]
   },
   {
@@ -303,70 +341,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alist = [1, 2, 3]\n",
-    "is_unique = len(set(alist)) == len(alist)\n",
-    "print(is_unique)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Safe Lookup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = {\"a\": 1, \"b\": 2}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x[\"a\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x[\"fish\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x.get(\"a\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x.get(\"fish\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x.get(\"fish\", \"tuna\") == \"tuna\""
+    "a_list = [1, 2, 3]\n",
+    "all_elements_unique = len(set(a_list)) == len(a_list)\n",
+    "print(all_elements_unique)"
    ]
   }
  ],
@@ -389,9 +366,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Fixes #42 by removing section on dictionaries being unordered (no longer relevant for recent version of Python) and makes some other updates to notebook content:

  * Reorders content so all dictionary material is together rather than having bit on `get` after section on sets
  * Adds more explanation to some areas to make material more self contained
  * Changes naming of `me` dictionary to more generic `person`