### PR TITLE
Removing references to partner and using snake case variable naming in structures exercise notebook

### DIFF
--- a/01-beginner/029structures.ipynb
+++ b/01-beginner/029structures.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Nested Lists and Dictionaries"
+    "## Nested lists and dictionaries"
    ]
   },
   {
@@ -28,9 +28,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "UCL = {'City': 'London', \n",
-    "     'Street': 'Gower Street',\n",
-    "     'Postcode': 'WC1E 6BT'}"
+    "ucl_address = {\n",
+    "    'City': 'London', \n",
+    "    'Street': 'Gower Street',\n",
+    "    'Postcode': 'WC1E 6BT'\n",
+    "}"
    ]
   },
   {
@@ -39,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MyHouse = {\n",
+    "house_address = {\n",
     "    'City': 'London',\n",
     "    'Street': 'Waterson Street',\n",
     "    'Postcode': 'E2 8HH'\n",
@@ -59,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "addresses = [UCL, MyHouse]"
+    "addresses = [ucl_address, house_address]"
    ]
   },
   {
@@ -84,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "UCL[\"People\"] = [\"Clare\", \"James\", \"Owain\"]"
+    "ucl_address[\"People\"] = [\"Clare\", \"James\", \"Owain\"]"
    ]
   },
   {
@@ -93,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MyHouse[\"People\"] = [\"Sue\", \"James\"]"
+    "house_address[\"People\"] = [\"Sue\", \"James\"]"
    ]
   },
   {
@@ -116,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can go further, e.g.:"
+    "We can go further, for example:"
    ]
   },
   {
@@ -125,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "UCL[\"Residential\"] = False"
+    "ucl_address[\"Residential\"] = False"
    ]
   },
   {
@@ -141,29 +143,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "leaders = [place[\"People\"][0] for place in addresses]\n",
-    "print(leaders)"
+    "total_number_of_people = sum([len(place[\"People\"]) for place in addresses])\n",
+    "print(total_number_of_people)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This was an example of a 'list comprehension', which is used to get data of this structure, and which we'll see more of in a moment..."
+    "The syntax inside the square brackets `[]` in the [`sum` function](https://docs.python.org/3/library/functions.html#sum) is an example of a _list comprehension_ - we'll learn more about these in a later notebook."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercise: a Maze Model."
+    "## Exercise: a maze model."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Work with a partner to design a data structure to represent a maze using dictionaries and lists."
+    "Design a data structure to represent a maze using dictionaries and lists."
    ]
   },
   {
@@ -261,9 +263,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Removes instruction to work with partner from exercise (as we typically now use this as a homework exercise). Also switches to more Pythonic `snake_case` variable names and updates code example applied to structure to something more generally relevant as previous example looks like it might have been a bit of an in-joke...